### PR TITLE
メモ一覧画面⇔ショップ一覧画面の画面遷移実装 #17

### DIFF
--- a/tokuMemo/ShopListView.swift
+++ b/tokuMemo/ShopListView.swift
@@ -7,7 +7,24 @@
 
 import SwiftUI
 
+struct Shop: Identifiable {
+    var id = UUID()
+    var name: String
+
+    init(_ name: String) {
+        self.name = name
+    } // initここまで
+} // Shopここまで
+
 struct ShopListView: View {
+    // サンプルデータ用
+    @State var shops: [Shop] = [
+        Shop("すべて"),
+        Shop("サンドラッグ新宿通り店")
+    ]
+    // モーダル終了処理
+    @Environment(\.dismiss) var dismiss
+
     var body: some View {
         ZStack {
             VStack {
@@ -16,14 +33,28 @@ struct ShopListView: View {
                 } // HStackここまで
 
                 List {
-                    Text("すべて")
-                    Text("スギ薬局中野南台")
-                    Text("ドンキホーテ新宿店")
+                    ForEach(shops) { shop in
+                        // セルの表示
+                        HStack {
+                            Text(shop.name)
+                            Spacer()
+                        } // HStackここまで
+
+                        // タップできる範囲を拡張する
+                        .contentShape(Rectangle())
+                        // タップ時の処理
+                        .onTapGesture {
+                            // タップしたカテゴリー名をTokuMemoListViewのカテゴリーボタンへ渡したい
+                            // 閉じる処理
+                            dismiss()
+                        } // .onTapGestureここまで
+                    } // ForEachここまで
                 } // Listここまで
                 .foregroundColor(.orange)
 
                 Button(action: {
                     // 閉じる処理
+                    dismiss()
                 }) {
                     Text("閉じる")
                         .frame(maxWidth: .infinity)

--- a/tokuMemo/TokuMemoListView.swift
+++ b/tokuMemo/TokuMemoListView.swift
@@ -12,6 +12,8 @@ struct TokuMemoListView: View {
     @State private var inputText = ""
     // カテゴリー画面表示フラグ
     @State private var showingModalCategoryListView = false
+    // ショップ画面表示フラグ
+    @State private var showingModalShopListView = false
 
     var body: some View {
         ZStack {
@@ -34,13 +36,18 @@ struct TokuMemoListView: View {
                     }
 
                     Button(action: {
-                        // タップしたらショップ選択画面へ遷移したい
+                        // ボタンタップでショップ画面フラグオン
+                        showingModalShopListView.toggle()
                     }) {
                         Text("ショップ")
                             .frame(maxWidth: .infinity)
                         Image(systemName: "chevron.right.circle")
                     }
-                } // HStackここまで
+                    // カテゴリ画面モーダル表示
+                    .fullScreenCover(isPresented: $showingModalShopListView) {
+                        ShopListView()
+                    }
+                }// HStackここまで
                 .font(.title3)
                 .buttonStyle(.bordered)
                 .padding(.horizontal)


### PR DESCRIPTION
<!-- Issueのテンプレートです。入力できるところを埋めてください。 -->
<!-- 記入しない項目は特になしと記入してください。。 -->

<!-- 関連Isuueを記載してください。close #の後にIssue番号を記載すると連携でき、プルリクのマージ時にIssueもcloseします。 -->
## 関連Isuue番号
close #17

<!-- 追加、または修正する機能の概要を記述してください。 -->
## 追加・変更の概要
issueに記載

<!-- 進捗状況をチェックボックスで管理してください。 -->
## タスクの進捗状況
- [1] ショップボタンタップでShopListViewへ画面遷移する
- [2] ショップ名を選択でTokuMemoListViewへ画面遷移する
- [3] 閉じるボタンタップでTokuMemoListViewへ画面遷移する

<!-- UIのキャプチャ、APIのリクエスト/レスポンス等、変更内容を明確に記述してください。 -->
## 変更内容

<!-- 影響範囲を予め明確に想定して記述してください。 -->
## 影響範囲
画面遷移のみのため特になし
<!-- 追加・変更した機能の操作方法を記述してください。キャプチャや動画を添付してください。 -->
## 操作方法
メモ一覧：ショップボタンをタップ
ショップ一覧：ショップ名をタップ、閉じるボタンをタップ